### PR TITLE
Fix footer text color

### DIFF
--- a/ui/src/ScreenSessionsView.tsx
+++ b/ui/src/ScreenSessionsView.tsx
@@ -100,6 +100,7 @@ export const ScreenSessionsView: React.FC = () => {
         textAlign="right"
         right="3vw"
         top="52vw"
+        color={Colors.navText}
       >
         {/* ^ position aligned with Bottom-left 'RubyKaigi 2024' logo */}
         {state === "in_session" ? <>Ongoing Sessions</> : null}


### PR DESCRIPTION
footer のセッション開始時間表示や On going 表示の文字色がデフォルトカラーだったので、 navText の色指定に変えました。

<img width="1047" height="586" alt="スクリーンショット 2026-04-22 13 36 41" src="https://github.com/user-attachments/assets/0dea83f5-25c3-4f88-89f7-b9f3b4ea78bb" />
