### PR TITLE
Add keynote-only mode to rotation

### DIFF
--- a/ui/src/Api.ts
+++ b/ui/src/Api.ts
@@ -124,6 +124,7 @@ export type ScreenControlFull = {
 
   show_sponsors: boolean;
   show_photo_sticker?: boolean;
+  keynote_only?: boolean;
   intermission: boolean;
   lightning_timer?: LightningTimer;
 
@@ -162,6 +163,7 @@ function dynamodbScreenControl(
 
     show_sponsors: possibleItem?.show_sponsors?.BOOL ?? true,
     show_photo_sticker: possibleItem?.show_photo_sticker?.BOOL ?? false,
+    keynote_only: possibleItem?.keynote_only?.BOOL ?? false,
     intermission: possibleItem?.intermission?.BOOL ?? false,
 
     message: ((map) =>
@@ -665,13 +667,14 @@ export const Api = {
         TableName: aws.config.dynamodb_table_name,
         Key: { pk: { S: pk }, sk: { S: sk } },
         UpdateExpression:
-          "set #track = :track, #mode = :mode, #rotated_views = :rotated_views, #show_sponsors = :show_sponsors, #show_photo_sticker = :show_photo_sticker, #intermission = :intermission, #message = :message, #lightning_timer = :lightning_timer, #main_caption = :main_caption, #subscreen_caption = :subscreen_caption, #subscreen_caption_hide_partial = :subscreen_caption_hide_partial, #subscreen_layout = :subscreen_layout, #updated_at = :updated_at",
+          "set #track = :track, #mode = :mode, #rotated_views = :rotated_views, #show_sponsors = :show_sponsors, #show_photo_sticker = :show_photo_sticker, #keynote_only = :keynote_only, #intermission = :intermission, #message = :message, #lightning_timer = :lightning_timer, #main_caption = :main_caption, #subscreen_caption = :subscreen_caption, #subscreen_caption_hide_partial = :subscreen_caption_hide_partial, #subscreen_layout = :subscreen_layout, #updated_at = :updated_at",
         ExpressionAttributeNames: {
           "#track": "track",
           "#mode": "mode",
           "#rotated_views": "rotated_views",
           "#show_sponsors": "show_sponsors",
           "#show_photo_sticker": "show_photo_sticker",
+          "#keynote_only": "keynote_only",
           "#intermission": "intermission",
           "#message": "message",
           "#lightning_timer": "lightning_timer",
@@ -691,6 +694,7 @@ export const Api = {
           },
           ":show_sponsors": { BOOL: value.show_sponsors },
           ":show_photo_sticker": { BOOL: !!value.show_photo_sticker },
+          ":keynote_only": { BOOL: !!value.keynote_only },
           ":intermission": { BOOL: value.intermission },
           ":message": value.message
             ? {

--- a/ui/src/ControlScreenForm.tsx
+++ b/ui/src/ControlScreenForm.tsx
@@ -56,6 +56,7 @@ type FormData = {
 
   show_sponsors: boolean;
   show_photo_sticker: boolean;
+  keynote_only: boolean;
 
   main_caption: CaptionSource;
 
@@ -89,6 +90,7 @@ function serverDataToFormData(input: ScreenControl): FormData {
 
     show_sponsors: input.show_sponsors,
     show_photo_sticker: input.show_photo_sticker ?? false,
+    keynote_only: input.keynote_only ?? false,
 
     main_caption: input.main_caption ?? "refiner",
 
@@ -121,6 +123,7 @@ function formDataToInput(
     rotated_views,
     show_sponsors: form.show_sponsors,
     show_photo_sticker: form.show_photo_sticker,
+    keynote_only: form.keynote_only,
     intermission: form.intermission,
     main_caption: form.main_caption,
     subscreen_layout: form.subscreen_layout,
@@ -204,6 +207,10 @@ export const ControlScreenForm: React.FC<{
                   <FormControl>
                     <FormLabel>Show sessions</FormLabel>
                     <Checkbox {...register("show_sessions")} />
+                  </FormControl>
+                  <FormControl>
+                    <FormLabel>Keynote-only (hide tracks B/C)</FormLabel>
+                    <Checkbox {...register("keynote_only")} />
                   </FormControl>
                   <FormControl>
                     <FormLabel>Show venue announcements</FormLabel>

--- a/ui/src/ScreenRotationView.tsx
+++ b/ui/src/ScreenRotationView.tsx
@@ -96,7 +96,9 @@ export const ScreenRotationView: React.FC = () => {
       {page.kind === "venue_announcements" ? (
         <ScreenVenueAnnouncementView ann={page.ann} />
       ) : null}
-      {page.kind === "sessions" ? <ScreenSessionsView /> : null}
+      {page.kind === "sessions" ? (
+        <ScreenSessionsView keynoteOnly={screen?.keynote_only ?? false} />
+      ) : null}
       {page.kind === "photo_sticker" ? <TamaribaPhotoStickerView /> : null}
     </>
   );

--- a/ui/src/ScreenSessionsView.tsx
+++ b/ui/src/ScreenSessionsView.tsx
@@ -33,9 +33,11 @@ type ConferenceStateAssumption =
   | "mixed"
   | "end_of_day";
 
-export const ScreenSessionsView: React.FC = () => {
+export const ScreenSessionsView: React.FC<{ keynoteOnly?: boolean }> = ({
+  keynoteOnly = false,
+}) => {
   const tick = useTick();
-  const recentSessions = useRecentSessions();
+  const recentSessions = useRecentSessions(keynoteOnly);
 
   let earliestStartUnix = undefined;
   if (recentSessions) {
@@ -115,7 +117,7 @@ export const ScreenSessionsView: React.FC = () => {
   );
 };
 
-function useRecentSessions() {
+function useRecentSessions(keynoteOnly: boolean = false) {
   const apictx = useApiContext(false);
   const tick = useTick();
   const { data: conferenceSessions } = Api.useConferenceSessions(apictx);
@@ -123,8 +125,12 @@ function useRecentSessions() {
   if (!conferenceSessions) return undefined;
   if (!apictx) return undefined;
 
+  const tracks = keynoteOnly
+    ? apictx.config.tracks.filter((t) => t === "a")
+    : apictx.config.tracks;
+
   const retval = new Map(
-    apictx.config.tracks.map((track) => {
+    tracks.map((track) => {
       const trackSessions = conferenceSessions.tracks.get(track) ?? [];
       const firstUnfinishedSession = trackSessions.find(
         (s) => tick.unix() <= s.ends_at


### PR DESCRIPTION
Hides tracks B and C from the sessions view when enabled, so only the track-A keynote slot is displayed during rotation.