### PR TITLE
Tag Japanese messages with lang="ja"

### DIFF
--- a/ui/src/ChatMessageView.tsx
+++ b/ui/src/ChatMessageView.tsx
@@ -132,6 +132,11 @@ const ChatAuthorName: React.FC<{ author: ChatSender; fg: string }> = ({
   );
 };
 
+const JAPANESE_PATTERN = /\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Han}/u;
+
 const ChatMessageText: React.FC<{ content: string }> = ({ content }) => {
+  if (JAPANESE_PATTERN.test(content)) {
+    return <span lang="ja">{content}</span>;
+  }
   return <span>{content}</span>;
 };


### PR DESCRIPTION
Detect Japanese script (Hiragana/Katakana/Han) in Discord chat content and add a lang attribute so browsers can apply Japanese font fallbacks and hyphenation rules.

<img width="920" height="690" alt="image (1)" src="https://github.com/user-attachments/assets/d9606fed-a22d-4928-8522-52ba59a22da0" />
